### PR TITLE
fix: Remove "ref to input" from payment key reference

### DIFF
--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -327,7 +327,15 @@ A Payment key reference in this CIP solves this problem by only allowing a refer
 
 The reference is a simple unsigned integer.
 The integer represent the index of the transaction outputs.
-For example, integer 0 refers to index 0 of the transaction outputs
+For example, integer 0 refers to index 0 of the transaction outputs.
+
+For the payment key to be validated, it must be witnessed in the transaction, this can be achieved by either:
+* Using the same payment key from an input to the transaction as an output.
+* If the payment key is not an input to the transaction, including it in the Required Signers field of the transaction.
+Payment keys which are not witnessed are invalid, as they can not be proven to both be:
+* Owned and controlled by the wallet signing the transaction and posting the registration.
+* Spendable.
+Ensuring this validity reduces the risk of invalid payments, or paying the wrong individuals, and eliminates the need to make "trial" payments to validate an address is payable.
 
 If the transaction output address **IS** also an input to the transaction,
 then the same proof has already been attached to the transaction.

--- a/CIP-XXXX/README.md
+++ b/CIP-XXXX/README.md
@@ -323,19 +323,11 @@ However, a fundamental problem with these metadata standards is there is no way 
 
 It is important that payment keys be verifiable and provably owned to the registrar.
 
-A Payment key reference in this CIP solves this problem by only allowing a reference to either a transaction input or output.
+A Payment key reference in this CIP solves this problem by only allowing a reference to transaction output.
 
-The reference is a simple signed integer.
-If the integer is positive, say N, it references the spent UTXO in the transaction input at index N - 1.
-For example, positive integer 1 refers to transaction input index 0.
-Because its required to prove one can spend a UTXO to post the transaction,
-the transaction itself proves that the Payment address being registered is both valid and owned by the registrar.
-
-If the reference is negative, say -N, it references a transaction output at index abs(N) - 1.
-The value is negated to determine the offset into the transaction output array.
-For example, negative integer -1 refers to transaction output index 0.
-
-Please note that `0` is an invalid reference.
+The reference is a simple unsigned integer.
+The integer represent the index of the transaction outputs.
+For example, integer 0 refers to index 0 of the transaction outputs
 
 If the transaction output address **IS** also an input to the transaction,
 then the same proof has already been attached to the transaction.

--- a/CIP-XXXX/x509-roles.cddl
+++ b/CIP-XXXX/x509-roles.cddl
@@ -124,11 +124,11 @@ key-local-ref = [ (x509-certs, offset)
 offset = uint
 
 ; Reference to a transaction output, used as the payment key for a role.
-; The reference integer represents the transaction index of the transaction output.
+; The reference unsigned integer represents the transaction index of the transaction output.
 ; The payment-key is considered valid if
 ; - The referenced payment key exist in the transaction.
 ; - The reference payment address must be witnessed within the witness set.
-payment-key = int
+payment-key = uint
 
 ; purpose specific data - Undefined here except for the key space
 ; Individual purposes can define these keys however they require.

--- a/CIP-XXXX/x509-roles.cddl
+++ b/CIP-XXXX/x509-roles.cddl
@@ -123,16 +123,11 @@ key-local-ref = [ (x509-certs, offset)
 ; Offset of the item in the specified set.  0 = first entry.
 offset = uint
 
-; Reference to a transaction input/output as the payment key to use for a role
-; Payment key (n) >= 0 = Use Transaction Input Key offset (n) as the payment key
-; Payment key (n) < 0 = Use Transaction Output Key offset -(n+1) as the payment key
-; IFF a transaction output payment key is defined the payment address must also be in
-; the required_signers of the transaction to ensure the payment address is owned and controlled
-; by the entity posting the registration.
-; If the referenced payment key does not exist in the transaction, or is not witnessed the entire
-; registration is to be considered invalid.
-; Note that reference to transaction input is currently unsupported due to the limitation
-; of past transaction references.
+; Reference to a transaction output, used as the payment key for a role.
+; The reference integer represents the transaction index of the transaction output.
+; The payment-key is considered valid if
+; - The referenced payment key exist in the transaction.
+; - The reference payment address must be witnessed within the witness set.
 payment-key = int
 
 ; purpose specific data - Undefined here except for the key space


### PR DESCRIPTION
Remove reference to transaction input since it cause complexity
- Payment key reference now can only be reference to transaction output, where the reference integer is the index number of the transaction output

Note that
```
transaction_body =
  { 0 : set<transaction_input>             ; inputs
  , 1 : [* transaction_output]
.....
```

```
post_alonzo_transaction_output =
  { 0 : address
  , 1 : value
  , ? 2 : datum_option ; datum option
  , ? 3 : script_ref   ; script reference
  }
```
